### PR TITLE
Fix function pickling when function's module is __main__

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,3 +48,4 @@ jobs:
           command: |
             cd ./dockered-slurm
             docker exec slurmctld bash -c "cd /cluster_tools && python36 -m pytest -s test.py"
+            docker exec slurmctld bash -c "cd /cluster_tools && python36 test.py"

--- a/cluster_tools/__init__.py
+++ b/cluster_tools/__init__.py
@@ -198,11 +198,13 @@ class SlurmExecutor(futures.Executor):
             )
 
     def dereference_main(self, fun): 
+        # Ensure that passed functions don't refer to __main__, but 
+        # instead to the actual module's name. Otherwise, unpickling
+        # wouldn't work from within this library.
+        #
+        # See https://stackoverflow.com/a/56008860/896760 for more context.
 
         if fun.__module__ == "__main__":
-            # Ensure that passed functions don't refer to __main__, but 
-            # instead to the actual module's name.
-            # See https://stackoverflow.com/a/56008860/896760
             import __main__
             main_module = __import__(__main__.__file__.split(".py")[0])
             fun = getattr(main_module, fun.__name__)

--- a/cluster_tools/__init__.py
+++ b/cluster_tools/__init__.py
@@ -197,9 +197,23 @@ class SlurmExecutor(futures.Executor):
                 "submit() was invoked on a SlurmExecutor instance even though shutdown() was executed for that instance."
             )
 
+    def dereference_main(self, fun): 
+
+        if fun.__module__ == "__main__":
+            # Ensure that passed functions don't refer to __main__, but 
+            # instead to the actual module's name.
+            # See https://stackoverflow.com/a/56008860/896760
+            import __main__
+            main_module = __import__(__main__.__file__.split(".py")[0])
+            fun = getattr(main_module, fun.__name__)
+
+        return fun
+
+
     def submit(self, fun, *args, **kwargs):
         """Submit a job to the pool."""
         fut = futures.Future()
+        fun = self.dereference_main(fun)
 
         self.ensure_not_shutdown()
 
@@ -283,13 +297,14 @@ class SlurmExecutor(futures.Executor):
         self.wait_thread.stop()
         self.wait_thread.join()
 
+
     def map(self, func, args, timeout=None, chunksize=None):
         if chunksize is not None:
             logging.warning(
                 "The provided chunksize parameter is ignored by SlurmExecutor."
             )
 
-
+        func = self.dereference_main(func)
         start_time = time.time()
 
         futs = self.map_to_futures(func, args)

--- a/cluster_tools/pickling.py
+++ b/cluster_tools/pickling.py
@@ -1,9 +1,10 @@
 import os
 if 'USE_CLOUDPICKLE' in os.environ:
 	import cloudpickle
-	pickle = cloudpickle
+	pickle_strategy = cloudpickle
 else:
 	import pickle
+	pickle_strategy = pickle
 
 from .util import warn_after
 
@@ -11,8 +12,8 @@ WARNING_TIMEOUT = 10 * 60 # seconds
 
 @warn_after("pickle.dumps", WARNING_TIMEOUT)
 def dumps(*args, **kwargs):
-	return pickle.dumps(*args, **kwargs)
+	return pickle_strategy.dumps(*args, **kwargs)
 
 @warn_after("pickle.loads", WARNING_TIMEOUT)
 def loads(*args, **kwargs):
-	return pickle.loads(*args, **kwargs)
+	return pickle_strategy.loads(*args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def _read(fn):
     return open(path).read()
 
 setup(name='cluster_tools',
-      version='1.15',
+      version='1.16',
       description='Utility library for easily distributing code execution on clusters',
       author='scalableminds',
       author_email='hello@scalableminds.com',

--- a/test.py
+++ b/test.py
@@ -114,10 +114,9 @@ def test_executor_args():
 
     # Test should succeed if the above lines don't raise an exception
 
-
 test_output_str = "Test-Output"
-def log():
-    logging.debug(test_output_str)
+def log(string):
+    logging.debug(string)
 
 def test_pickled_logging():
 
@@ -128,7 +127,7 @@ def test_pickled_logging():
         with cluster_tools.get_executor(
             "slurm", debug=True, keep_logs=True, job_resources={"mem": "10M"}, logging_config=logging_config
         ) as executor:
-            fut = executor.submit(log)
+            fut = executor.submit(log, test_output_str)
             fut.result()
 
             output = ".cfut/slurmpy.stdout.{}.log".format(fut.slurm_jobid)
@@ -141,3 +140,8 @@ def test_pickled_logging():
 
     debug_out = execute_with_log_level(logging.INFO)
     assert not (test_output_str in debug_out)
+
+
+if __name__ == "__main__":
+    # Validate that slurm_executor.submit also works when being called from a __main__ module
+    test_pickled_logging()


### PR DESCRIPTION
Pickle uses the module name of the object to serialize that object. However, if the object was defined in the module which was used to execute the python code, the serialized module name is `__main__`. In that case, unpickling does only work, when using the same main module. However, that is never the case when using cluster tools.

This PR adds a dynamic re-import for such objects.