### PR TITLE
Implement map_to_futures for all executors

### DIFF
--- a/cluster_tools/__init__.py
+++ b/cluster_tools/__init__.py
@@ -402,7 +402,7 @@ class WrappedProcessPoolExecutor(ProcessPoolExecutor):
 
     def map_unordered(self, func, args):
 
-        futs = [self.submit(func, arg) for arg in args]
+        futs = self.map_to_futures(func, args)
 
         # Return a separate generator to avoid that map_unordered
         # is executed lazily (otherwise, jobs would be submitted
@@ -412,6 +412,11 @@ class WrappedProcessPoolExecutor(ProcessPoolExecutor):
                 yield fut.result()
 
         return result_generator()
+
+    def map_to_futures(self, func, args):
+
+        futs = [self.submit(func, arg) for arg in args]
+        return futs
 
 
 class SequentialExecutor(WrappedProcessPoolExecutor):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def _read(fn):
     return open(path).read()
 
 setup(name='cluster_tools',
-      version='1.22',
+      version='1.23',
       description='Utility library for easily distributing code execution on clusters',
       author='scalableminds',
       author_email='hello@scalableminds.com',

--- a/test.py
+++ b/test.py
@@ -73,6 +73,21 @@ def test_unordered_map():
             for duration, result in zip(durations, results):
                 assert result == duration
 
+def test_map_to_futures():
+    for exc in get_executors():
+        with exc:
+            durations = [15, 1]
+            futures = exc.map_to_futures(sleep, durations)
+            results = []
+
+            for i, duration in enumerate(concurrent.futures.as_completed(futures)):
+                results.append(duration.result())
+
+            if not isinstance(exc, cluster_tools.SequentialExecutor):
+                durations.sort()
+
+            for duration, result in zip(durations, results):
+                assert result == duration
 
 def test_map():
     def run_map(executor):

--- a/test.py
+++ b/test.py
@@ -21,7 +21,7 @@ logging.basicConfig()
 def get_executors():
     return [
         cluster_tools.get_executor(
-            "slurm", debug=True, keep_logs=True, job_resources={"mem": "10M"}
+            "slurm", debug=True, keep_logs=True, job_resources={"mem": "100M"}
         ),
         cluster_tools.get_executor("multiprocessing", max_workers=5),
         cluster_tools.get_executor("sequential"),


### PR DESCRIPTION
This change gives us job array support without losing control over the handling of futures (e.g., as_completed can be used etc.).