### PR TITLE
Don’t install python2 futures backport on python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name='cluster_tools',
       packages=find_packages(),
       install_requires=[
           'cloudpickle',
-          'futures',
+          'futures; python_version == "2.7"'
       ],
 
       classifiers=[


### PR DESCRIPTION
quote from https://pypi.org/project/futures/
```
This is a backport of the concurrent.futures standard library module to Python 2.

It should not be installed on Python 3, although there should be no harm in doing so, as the standard library takes precedence over third party libraries.

To conditionally require this library only on Python 2, you can do this in your setup.py:


setup(
    ...
    install_requires={
        'futures; python_version == "2.7"'
    }
)

```