### PR TITLE
Use sacct as a fallback for discovery of crashed jobs

### DIFF
--- a/cluster_tools/schedulers/slurm.py
+++ b/cluster_tools/schedulers/slurm.py
@@ -114,7 +114,7 @@ class SlurmExecutor(ClusterExecutor):
         # If the output file was not found, we determine the job status so that
         # we can recognize jobs which failed hard (in this case, they don't produce output files)
         stdout, _, exit_code = call("_scontrol show job {}".format(job_id))
-        stdout = str(stdout)
+        stdout = stdout.decode("utf8")
 
         if exit_code == 0:
             job_state_search = re.search('JobState=([a-zA-Z_]*)', str(stdout))
@@ -124,9 +124,10 @@ class SlurmExecutor(ClusterExecutor):
                 logging.error("Could not extract slurm job state? {}".format(stdout[0:10]))
         else:
             stdout, _, exit_code = call("sacct -j {} -o State -P".format(job_id))
+            stdout = stdout.decode("utf8")
 
             if exit_code == 0:
-                job_states = stdout.split(b"\n")[1:]
+                job_states = stdout.split("\n")[1:]
         
         if len(job_states) == 0:
             logging.error(

--- a/cluster_tools/schedulers/slurm.py
+++ b/cluster_tools/schedulers/slurm.py
@@ -113,7 +113,7 @@ class SlurmExecutor(ClusterExecutor):
 
         # If the output file was not found, we determine the job status so that
         # we can recognize jobs which failed hard (in this case, they don't produce output files)
-        stdout, _, exit_code = call("_scontrol show job {}".format(job_id))
+        stdout, _, exit_code = call("scontrol show job {}".format(job_id))
         stdout = stdout.decode("utf8")
 
         if exit_code == 0:
@@ -140,17 +140,13 @@ class SlurmExecutor(ClusterExecutor):
         
         logging.warn("job_states: {}".format(job_states))
         if matches_states(SLURM_STATES["Failure"]):
-            logging.warn("found state to be failed")
             return "failed"
         elif matches_states(SLURM_STATES["Ignore"]):
-            logging.warn("found state to be ignore")
             return "ignore"
         elif matches_states(SLURM_STATES["Unclear"]):
             logging.warn("The job state for {} is {}. It's unclear whether the job will recover. Will wait further".format(job_id, job_state))
-            logging.warn("found state to be ignore")
             return "ignore"
         elif matches_states(SLURM_STATES["Success"]):
-            logging.warn("found state to be completed")
             return "completed"
         else:
             logging.error("Unhandled slurm job state? {}".format(job_states))

--- a/cluster_tools/schedulers/slurm.py
+++ b/cluster_tools/schedulers/slurm.py
@@ -107,37 +107,51 @@ class SlurmExecutor(ClusterExecutor):
 
         return submit_text("\n".join(script_lines))
 
-
-
     def check_for_crashed_job(self, job_id) -> Union["failed", "ignore", "completed"]:
+
+        job_states = []
 
         # If the output file was not found, we determine the job status so that
         # we can recognize jobs which failed hard (in this case, they don't produce output files)
-        stdout, _, exit_code = call("scontrol show job {}".format(job_id))
+        stdout, _, exit_code = call("_scontrol show job {}".format(job_id))
+        stdout = str(stdout)
 
-        if exit_code != 0:
-            logging.error(
-                "Couldn't call scontrol to determine job's status. {}. Continuing to poll for output file. This could be an indicator for a failed job which was already cleaned up from the slurm db. If this is the case, the process will hang forever."
-            )
-            return "ignore"
-        else:
+        if exit_code == 0:
             job_state_search = re.search('JobState=([a-zA-Z_]*)', str(stdout))
-
             if job_state_search:
-                job_state = job_state_search.group(1)
-
-                if job_state in SLURM_STATES["Failure"]:
-                    return "failed"
-                elif job_state in SLURM_STATES["Ignore"]:
-                    return "ignore"
-                elif job_state in SLURM_STATES["Unclear"]:
-                    logging.warn("The job state for {} is {}. It's unclear whether the job will recover. Will wait further".format(job_id, job_state))
-                    return "ignore"
-                elif job_state in SLURM_STATES["Success"]:
-                    return "completed"
-                else:
-                    logging.error("Unhandled slurm job state? {}".format(job_state))
-                    return "ignore"
+                job_states = [job_state_search.group(1)]
             else:
                 logging.error("Could not extract slurm job state? {}".format(stdout[0:10]))
-                return "ignore"
+        else:
+            stdout, _, exit_code = call("sacct -j {} -o State -P".format(job_id))
+
+            if exit_code == 0:
+                job_states = stdout.split(b"\n")[1:]
+        
+        if len(job_states) == 0:
+            logging.error(
+                "Couldn't call scontrol nor sacct to determine job's status. Continuing to poll for output file. This could be an indicator for a failed job which was already cleaned up from the slurm db. If this is the case, the process will hang forever."
+            )
+            return "ignore"
+
+        def matches_states(slurm_states):
+            return len(list(set(job_states) & set(slurm_states))) > 0
+        
+        logging.warn("job_states: {}".format(job_states))
+        if matches_states(SLURM_STATES["Failure"]):
+            logging.warn("found state to be failed")
+            return "failed"
+        elif matches_states(SLURM_STATES["Ignore"]):
+            logging.warn("found state to be ignore")
+            return "ignore"
+        elif matches_states(SLURM_STATES["Unclear"]):
+            logging.warn("The job state for {} is {}. It's unclear whether the job will recover. Will wait further".format(job_id, job_state))
+            logging.warn("found state to be ignore")
+            return "ignore"
+        elif matches_states(SLURM_STATES["Success"]):
+            logging.warn("found state to be completed")
+            return "completed"
+        else:
+            logging.error("Unhandled slurm job state? {}".format(job_states))
+            return "ignore"
+    

--- a/cluster_tools/schedulers/slurm.py
+++ b/cluster_tools/schedulers/slurm.py
@@ -143,7 +143,7 @@ class SlurmExecutor(ClusterExecutor):
         elif matches_states(SLURM_STATES["Ignore"]):
             return "ignore"
         elif matches_states(SLURM_STATES["Unclear"]):
-            logging.warn("The job state for {} is {}. It's unclear whether the job will recover. Will wait further".format(job_id, job_state))
+            logging.warn("The job state for {} is {}. It's unclear whether the job will recover. Will wait further".format(job_id, job_states))
             return "ignore"
         elif matches_states(SLURM_STATES["Success"]):
             return "completed"

--- a/cluster_tools/schedulers/slurm.py
+++ b/cluster_tools/schedulers/slurm.py
@@ -137,8 +137,7 @@ class SlurmExecutor(ClusterExecutor):
 
         def matches_states(slurm_states):
             return len(list(set(job_states) & set(slurm_states))) > 0
-        
-        logging.warn("job_states: {}".format(job_states))
+
         if matches_states(SLURM_STATES["Failure"]):
             return "failed"
         elif matches_states(SLURM_STATES["Ignore"]):

--- a/test.py
+++ b/test.py
@@ -23,24 +23,24 @@ def get_executors():
         cluster_tools.get_executor(
             "slurm", debug=True, keep_logs=True, job_resources={"mem": "100M"}
         ),
-        cluster_tools.get_executor("multiprocessing", max_workers=5),
-        cluster_tools.get_executor("sequential"),
-        cluster_tools.get_executor("test_pickling"),
+        # cluster_tools.get_executor("multiprocessing", max_workers=5),
+        # cluster_tools.get_executor("sequential"),
+        # cluster_tools.get_executor("test_pickling"),
         # cluster_tools.get_executor("pbs"),
     ]
 
 
-def test_submit():
-    def run_square_numbers(executor):
-        with executor:
-            job_count = 1
-            job_range = range(job_count)
-            futures = [executor.submit(square, n) for n in job_range]
-            for future, job_index in zip(futures, job_range):
-                assert future.result() == square(job_index)
+# def test_submit():
+#     def run_square_numbers(executor):
+#         with executor:
+#             job_count = 1
+#             job_range = range(job_count)
+#             futures = [executor.submit(square, n) for n in job_range]
+#             for future, job_index in zip(futures, job_range):
+#                 assert future.result() == square(job_index)
 
-    for exc in get_executors():
-        run_square_numbers(exc)
+#     for exc in get_executors():
+#         run_square_numbers(exc)
 
 
 
@@ -61,142 +61,142 @@ def test_unordered_sleep():
                 assert future.result() == duration
 
 
-def test_unordered_map():
-    for exc in get_executors():
-        with exc:
-            durations = [15, 1]
-            results_gen = exc.map_unordered(sleep, durations)
-            results = list(results_gen)
+# def test_unordered_map():
+#     for exc in get_executors():
+#         with exc:
+#             durations = [15, 1]
+#             results_gen = exc.map_unordered(sleep, durations)
+#             results = list(results_gen)
 
-            if not isinstance(exc, cluster_tools.SequentialExecutor):
-                durations.sort()
+#             if not isinstance(exc, cluster_tools.SequentialExecutor):
+#                 durations.sort()
 
-            for duration, result in zip(durations, results):
-                assert result == duration
+#             for duration, result in zip(durations, results):
+#                 assert result == duration
 
-def test_map_to_futures():
-    for exc in get_executors():
-        with exc:
-            durations = [15, 1]
-            futures = exc.map_to_futures(sleep, durations)
-            results = []
+# def test_map_to_futures():
+#     for exc in get_executors():
+#         with exc:
+#             durations = [15, 1]
+#             futures = exc.map_to_futures(sleep, durations)
+#             results = []
 
-            for i, duration in enumerate(concurrent.futures.as_completed(futures)):
-                results.append(duration.result())
+#             for i, duration in enumerate(concurrent.futures.as_completed(futures)):
+#                 results.append(duration.result())
 
-            if not isinstance(exc, cluster_tools.SequentialExecutor):
-                durations.sort()
+#             if not isinstance(exc, cluster_tools.SequentialExecutor):
+#                 durations.sort()
 
-            for duration, result in zip(durations, results):
-                assert result == duration
+#             for duration, result in zip(durations, results):
+#                 assert result == duration
 
-def test_map():
-    def run_map(executor):
-        with executor:
-            result = list(executor.map(square, [2, 3, 4]))
-            assert result == [4, 9, 16]
+# def test_map():
+#     def run_map(executor):
+#         with executor:
+#             result = list(executor.map(square, [2, 3, 4]))
+#             assert result == [4, 9, 16]
 
-    for exc in get_executors():
-        run_map(exc)
-
-
-def test_map_lazy():
-    def run_map(executor):
-        with executor:
-            result = executor.map(square, [2, 3, 4])
-        assert list(result) == [4, 9, 16]
-
-    for exc in get_executors():
-        run_map(exc)
+#     for exc in get_executors():
+#         run_map(exc)
 
 
-def test_slurm_submit_returns_job_ids():
-    exc = cluster_tools.get_executor("slurm", debug=True, keep_logs=True)
-    with exc:
-        future = exc.submit(square, 2)
-        assert isinstance(future.cluster_jobid, int)
-        assert future.cluster_jobid > 0
-        assert future.result() == 4
+# def test_map_lazy():
+#     def run_map(executor):
+#         with executor:
+#             result = executor.map(square, [2, 3, 4])
+#         assert list(result) == [4, 9, 16]
+
+#     for exc in get_executors():
+#         run_map(exc)
 
 
-def test_executor_args():
-    def pass_with(exc):
-        with exc:
-            pass
-
-    pass_with(cluster_tools.get_executor(
-        "slurm", job_resources={"mem": "10M"}, non_existent_arg=True
-    ))
-    pass_with(cluster_tools.get_executor("multiprocessing", non_existent_arg=True))
-    pass_with(cluster_tools.get_executor("sequential", non_existent_arg=True))
-
-    # Test should succeed if the above lines don't raise an exception
-
-test_output_str = "Test-Output"
-def log(string):
-    logging.debug(string)
-
-def test_pickled_logging():
-
-    def execute_with_log_level(log_level):
-        logging_config = {
-            "level": log_level,
-        }
-        with cluster_tools.get_executor(
-            "slurm", debug=True, keep_logs=True, job_resources={"mem": "10M"}, logging_config=logging_config
-        ) as executor:
-            fut = executor.submit(log, test_output_str)
-            fut.result()
-
-            output = ".cfut/slurmpy.stdout.{}.log".format(fut.cluster_jobid)
-
-            with open(output, 'r') as file:
-                return file.read()
-
-    debug_out = execute_with_log_level(logging.DEBUG)
-    assert test_output_str in debug_out
-
-    debug_out = execute_with_log_level(logging.INFO)
-    assert not (test_output_str in debug_out)
+# def test_slurm_submit_returns_job_ids():
+#     exc = cluster_tools.get_executor("slurm", debug=True, keep_logs=True)
+#     with exc:
+#         future = exc.submit(square, 2)
+#         assert isinstance(future.cluster_jobid, int)
+#         assert future.cluster_jobid > 0
+#         assert future.result() == 4
 
 
-class DummyEnum(Enum):
-    BANANA = 0
-    APPLE = 1
-    PEAR = 2
+# def test_executor_args():
+#     def pass_with(exc):
+#         with exc:
+#             pass
 
-def enum_consumer(value):
-    assert value == DummyEnum.BANANA
+#     pass_with(cluster_tools.get_executor(
+#         "slurm", job_resources={"mem": "10M"}, non_existent_arg=True
+#     ))
+#     pass_with(cluster_tools.get_executor("multiprocessing", non_existent_arg=True))
+#     pass_with(cluster_tools.get_executor("sequential", non_existent_arg=True))
 
-def test_cloudpickle_serialization():
-    enum_consumer_inner = enum_consumer
+#     # Test should succeed if the above lines don't raise an exception
 
-    for fn in [enum_consumer, enum_consumer_inner]:
-        try:
-            with cluster_tools.get_executor(
-                "test_pickling"
-            ) as executor:
-                fut = executor.submit(fn, DummyEnum.BANANA)
-            assert fn == enum_consumer
-        except Exception:
-            assert fn != enum_consumer
+# test_output_str = "Test-Output"
+# def log(string):
+#     logging.debug(string)
 
-    assert True
+# def test_pickled_logging():
 
-class TestClass:
-    pass
+#     def execute_with_log_level(log_level):
+#         logging_config = {
+#             "level": log_level,
+#         }
+#         with cluster_tools.get_executor(
+#             "slurm", debug=True, keep_logs=True, job_resources={"mem": "10M"}, logging_config=logging_config
+#         ) as executor:
+#             fut = executor.submit(log, test_output_str)
+#             fut.result()
 
-def deref_fun_helper(obj):
-    clss, inst, one, two = obj
-    assert one == 1
-    assert two == 2
-    assert isinstance(inst, clss)
+#             output = ".cfut/slurmpy.stdout.{}.log".format(fut.cluster_jobid)
 
-def test_dereferencing_main():
-    with cluster_tools.get_executor("slurm", debug=True, keep_logs=True, job_resources={"mem": "10M"}) as executor:
-        fut = executor.submit(deref_fun_helper, (TestClass, TestClass(), 1, 2))
-        fut.result()
+#             with open(output, 'r') as file:
+#                 return file.read()
 
-if __name__ == "__main__":
-    # Validate that slurm_executor.submit also works when being called from a __main__ module
-    test_dereferencing_main()
+#     debug_out = execute_with_log_level(logging.DEBUG)
+#     assert test_output_str in debug_out
+
+#     debug_out = execute_with_log_level(logging.INFO)
+#     assert not (test_output_str in debug_out)
+
+
+# class DummyEnum(Enum):
+#     BANANA = 0
+#     APPLE = 1
+#     PEAR = 2
+
+# def enum_consumer(value):
+#     assert value == DummyEnum.BANANA
+
+# def test_cloudpickle_serialization():
+#     enum_consumer_inner = enum_consumer
+
+#     for fn in [enum_consumer, enum_consumer_inner]:
+#         try:
+#             with cluster_tools.get_executor(
+#                 "test_pickling"
+#             ) as executor:
+#                 fut = executor.submit(fn, DummyEnum.BANANA)
+#             assert fn == enum_consumer
+#         except Exception:
+#             assert fn != enum_consumer
+
+#     assert True
+
+# class TestClass:
+#     pass
+
+# def deref_fun_helper(obj):
+#     clss, inst, one, two = obj
+#     assert one == 1
+#     assert two == 2
+#     assert isinstance(inst, clss)
+
+# def test_dereferencing_main():
+#     with cluster_tools.get_executor("slurm", debug=True, keep_logs=True, job_resources={"mem": "10M"}) as executor:
+#         fut = executor.submit(deref_fun_helper, (TestClass, TestClass(), 1, 2))
+#         fut.result()
+
+# if __name__ == "__main__":
+#     # Validate that slurm_executor.submit also works when being called from a __main__ module
+#     test_dereferencing_main()

--- a/test.py
+++ b/test.py
@@ -26,7 +26,7 @@ def get_executors():
         cluster_tools.get_executor("multiprocessing", max_workers=5),
         cluster_tools.get_executor("sequential"),
         cluster_tools.get_executor("test_pickling"),
-        cluster_tools.get_executor("pbs"),
+        # cluster_tools.get_executor("pbs"),
     ]
 
 

--- a/test.py
+++ b/test.py
@@ -23,26 +23,24 @@ def get_executors():
         cluster_tools.get_executor(
             "slurm", debug=True, keep_logs=True, job_resources={"mem": "100M"}
         ),
-        # cluster_tools.get_executor("multiprocessing", max_workers=5),
-        # cluster_tools.get_executor("sequential"),
-        # cluster_tools.get_executor("test_pickling"),
-        # cluster_tools.get_executor("pbs"),
+        cluster_tools.get_executor("multiprocessing", max_workers=5),
+        cluster_tools.get_executor("sequential"),
+        cluster_tools.get_executor("test_pickling"),
+        cluster_tools.get_executor("pbs"),
     ]
 
 
-# def test_submit():
-#     def run_square_numbers(executor):
-#         with executor:
-#             job_count = 1
-#             job_range = range(job_count)
-#             futures = [executor.submit(square, n) for n in job_range]
-#             for future, job_index in zip(futures, job_range):
-#                 assert future.result() == square(job_index)
+def test_submit():
+    def run_square_numbers(executor):
+        with executor:
+            job_count = 3
+            job_range = range(job_count)
+            futures = [executor.submit(square, n) for n in job_range]
+            for future, job_index in zip(futures, job_range):
+                assert future.result() == square(job_index)
 
-#     for exc in get_executors():
-#         run_square_numbers(exc)
-
-
+    for exc in get_executors():
+        run_square_numbers(exc)
 
 
 def test_unordered_sleep():
@@ -61,142 +59,142 @@ def test_unordered_sleep():
                 assert future.result() == duration
 
 
-# def test_unordered_map():
-#     for exc in get_executors():
-#         with exc:
-#             durations = [15, 1]
-#             results_gen = exc.map_unordered(sleep, durations)
-#             results = list(results_gen)
+def test_unordered_map():
+    for exc in get_executors():
+        with exc:
+            durations = [15, 1]
+            results_gen = exc.map_unordered(sleep, durations)
+            results = list(results_gen)
 
-#             if not isinstance(exc, cluster_tools.SequentialExecutor):
-#                 durations.sort()
+            if not isinstance(exc, cluster_tools.SequentialExecutor):
+                durations.sort()
 
-#             for duration, result in zip(durations, results):
-#                 assert result == duration
+            for duration, result in zip(durations, results):
+                assert result == duration
 
-# def test_map_to_futures():
-#     for exc in get_executors():
-#         with exc:
-#             durations = [15, 1]
-#             futures = exc.map_to_futures(sleep, durations)
-#             results = []
+def test_map_to_futures():
+    for exc in get_executors():
+        with exc:
+            durations = [15, 1]
+            futures = exc.map_to_futures(sleep, durations)
+            results = []
 
-#             for i, duration in enumerate(concurrent.futures.as_completed(futures)):
-#                 results.append(duration.result())
+            for i, duration in enumerate(concurrent.futures.as_completed(futures)):
+                results.append(duration.result())
 
-#             if not isinstance(exc, cluster_tools.SequentialExecutor):
-#                 durations.sort()
+            if not isinstance(exc, cluster_tools.SequentialExecutor):
+                durations.sort()
 
-#             for duration, result in zip(durations, results):
-#                 assert result == duration
+            for duration, result in zip(durations, results):
+                assert result == duration
 
-# def test_map():
-#     def run_map(executor):
-#         with executor:
-#             result = list(executor.map(square, [2, 3, 4]))
-#             assert result == [4, 9, 16]
+def test_map():
+    def run_map(executor):
+        with executor:
+            result = list(executor.map(square, [2, 3, 4]))
+            assert result == [4, 9, 16]
 
-#     for exc in get_executors():
-#         run_map(exc)
-
-
-# def test_map_lazy():
-#     def run_map(executor):
-#         with executor:
-#             result = executor.map(square, [2, 3, 4])
-#         assert list(result) == [4, 9, 16]
-
-#     for exc in get_executors():
-#         run_map(exc)
+    for exc in get_executors():
+        run_map(exc)
 
 
-# def test_slurm_submit_returns_job_ids():
-#     exc = cluster_tools.get_executor("slurm", debug=True, keep_logs=True)
-#     with exc:
-#         future = exc.submit(square, 2)
-#         assert isinstance(future.cluster_jobid, int)
-#         assert future.cluster_jobid > 0
-#         assert future.result() == 4
+def test_map_lazy():
+    def run_map(executor):
+        with executor:
+            result = executor.map(square, [2, 3, 4])
+        assert list(result) == [4, 9, 16]
+
+    for exc in get_executors():
+        run_map(exc)
 
 
-# def test_executor_args():
-#     def pass_with(exc):
-#         with exc:
-#             pass
-
-#     pass_with(cluster_tools.get_executor(
-#         "slurm", job_resources={"mem": "10M"}, non_existent_arg=True
-#     ))
-#     pass_with(cluster_tools.get_executor("multiprocessing", non_existent_arg=True))
-#     pass_with(cluster_tools.get_executor("sequential", non_existent_arg=True))
-
-#     # Test should succeed if the above lines don't raise an exception
-
-# test_output_str = "Test-Output"
-# def log(string):
-#     logging.debug(string)
-
-# def test_pickled_logging():
-
-#     def execute_with_log_level(log_level):
-#         logging_config = {
-#             "level": log_level,
-#         }
-#         with cluster_tools.get_executor(
-#             "slurm", debug=True, keep_logs=True, job_resources={"mem": "10M"}, logging_config=logging_config
-#         ) as executor:
-#             fut = executor.submit(log, test_output_str)
-#             fut.result()
-
-#             output = ".cfut/slurmpy.stdout.{}.log".format(fut.cluster_jobid)
-
-#             with open(output, 'r') as file:
-#                 return file.read()
-
-#     debug_out = execute_with_log_level(logging.DEBUG)
-#     assert test_output_str in debug_out
-
-#     debug_out = execute_with_log_level(logging.INFO)
-#     assert not (test_output_str in debug_out)
+def test_slurm_submit_returns_job_ids():
+    exc = cluster_tools.get_executor("slurm", debug=True, keep_logs=True)
+    with exc:
+        future = exc.submit(square, 2)
+        assert isinstance(future.cluster_jobid, int)
+        assert future.cluster_jobid > 0
+        assert future.result() == 4
 
 
-# class DummyEnum(Enum):
-#     BANANA = 0
-#     APPLE = 1
-#     PEAR = 2
+def test_executor_args():
+    def pass_with(exc):
+        with exc:
+            pass
 
-# def enum_consumer(value):
-#     assert value == DummyEnum.BANANA
+    pass_with(cluster_tools.get_executor(
+        "slurm", job_resources={"mem": "10M"}, non_existent_arg=True
+    ))
+    pass_with(cluster_tools.get_executor("multiprocessing", non_existent_arg=True))
+    pass_with(cluster_tools.get_executor("sequential", non_existent_arg=True))
 
-# def test_cloudpickle_serialization():
-#     enum_consumer_inner = enum_consumer
+    # Test should succeed if the above lines don't raise an exception
 
-#     for fn in [enum_consumer, enum_consumer_inner]:
-#         try:
-#             with cluster_tools.get_executor(
-#                 "test_pickling"
-#             ) as executor:
-#                 fut = executor.submit(fn, DummyEnum.BANANA)
-#             assert fn == enum_consumer
-#         except Exception:
-#             assert fn != enum_consumer
+test_output_str = "Test-Output"
+def log(string):
+    logging.debug(string)
 
-#     assert True
+def test_pickled_logging():
 
-# class TestClass:
-#     pass
+    def execute_with_log_level(log_level):
+        logging_config = {
+            "level": log_level,
+        }
+        with cluster_tools.get_executor(
+            "slurm", debug=True, keep_logs=True, job_resources={"mem": "10M"}, logging_config=logging_config
+        ) as executor:
+            fut = executor.submit(log, test_output_str)
+            fut.result()
 
-# def deref_fun_helper(obj):
-#     clss, inst, one, two = obj
-#     assert one == 1
-#     assert two == 2
-#     assert isinstance(inst, clss)
+            output = ".cfut/slurmpy.stdout.{}.log".format(fut.cluster_jobid)
 
-# def test_dereferencing_main():
-#     with cluster_tools.get_executor("slurm", debug=True, keep_logs=True, job_resources={"mem": "10M"}) as executor:
-#         fut = executor.submit(deref_fun_helper, (TestClass, TestClass(), 1, 2))
-#         fut.result()
+            with open(output, 'r') as file:
+                return file.read()
 
-# if __name__ == "__main__":
-#     # Validate that slurm_executor.submit also works when being called from a __main__ module
-#     test_dereferencing_main()
+    debug_out = execute_with_log_level(logging.DEBUG)
+    assert test_output_str in debug_out
+
+    debug_out = execute_with_log_level(logging.INFO)
+    assert not (test_output_str in debug_out)
+
+
+class DummyEnum(Enum):
+    BANANA = 0
+    APPLE = 1
+    PEAR = 2
+
+def enum_consumer(value):
+    assert value == DummyEnum.BANANA
+
+def test_cloudpickle_serialization():
+    enum_consumer_inner = enum_consumer
+
+    for fn in [enum_consumer, enum_consumer_inner]:
+        try:
+            with cluster_tools.get_executor(
+                "test_pickling"
+            ) as executor:
+                fut = executor.submit(fn, DummyEnum.BANANA)
+            assert fn == enum_consumer
+        except Exception:
+            assert fn != enum_consumer
+
+    assert True
+
+class TestClass:
+    pass
+
+def deref_fun_helper(obj):
+    clss, inst, one, two = obj
+    assert one == 1
+    assert two == 2
+    assert isinstance(inst, clss)
+
+def test_dereferencing_main():
+    with cluster_tools.get_executor("slurm", debug=True, keep_logs=True, job_resources={"mem": "10M"}) as executor:
+        fut = executor.submit(deref_fun_helper, (TestClass, TestClass(), 1, 2))
+        fut.result()
+
+if __name__ == "__main__":
+    # Validate that slurm_executor.submit also works when being called from a __main__ module
+    test_dereferencing_main()


### PR DESCRIPTION
in addition to `scontrol`, `sacct` is also used to check for crashed jobs since some slurm setups don't keep accounting information long enough in memory.