### PR TITLE
Use setuptools-scm to auto-bump version number along with git tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,8 @@ def _read(fn):
 
 setup(name='cluster_tools',
       version='v1.28',
+      use_scm_version=True,
+      setup_requires=['setuptools_scm'],
       description='Utility library for easily distributing code execution on clusters',
       author='scalableminds',
       author_email='hello@scalableminds.com',


### PR DESCRIPTION
Instead of manually updating the package version in setup.py, we can simply create git tags/releases via github (as we already doing it) and the version will be automatically reflect this according to this scheme: https://github.com/pypa/setuptools_scm/#default-versioning-scheme

fixes #30 
