### PR TITLE
Add retry for reading outfile

### DIFF
--- a/cluster_tools/schedulers/slurm.py
+++ b/cluster_tools/schedulers/slurm.py
@@ -71,7 +71,7 @@ class SlurmExecutor(ClusterExecutor):
     def format_log_file_name(self, jobid):
         # dirty workaround: job id can be a compound id (jobid_jobindex)
         # which we always put into log files with jobid.jobindex format
-        jobid = jobid.replace("_", ".")
+        jobid = str(jobid).replace("_", ".")
         return local_filename("slurmpy.stdout.{}.log").format(str(jobid))
 
     def inner_submit(

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ def _read(fn):
     return open(path).read()
 
 setup(name='cluster_tools',
-      version='v1.28',
       use_scm_version=True,
       setup_requires=['setuptools_scm'],
       description='Utility library for easily distributing code execution on clusters',


### PR DESCRIPTION
For distributed file systems the out file might be unavailable for some time even though the job already finished. Add a retry for that.

Also reduce polling interval from 1 s to 2 s to save some CPU time.