### PR TITLE
Warn about uncaught/unhandled futures

### DIFF
--- a/cluster_tools/__init__.py
+++ b/cluster_tools/__init__.py
@@ -5,7 +5,7 @@ import sys
 import threading
 from .schedulers.slurm import SlurmExecutor
 from .schedulers.pbs import PBSExecutor
-from .util import random_string, call, enrich_futures_with_uncaught_warning
+from .util import random_string, call, enrich_future_with_uncaught_warning
 from . import pickling
 import importlib
 
@@ -28,7 +28,7 @@ class WrappedProcessPoolExecutor(ProcessPoolExecutor):
     def submit(self, *args, **kwargs):
 
         fut = super().submit(*args, **kwargs)
-        enrich_futures_with_uncaught_warning(fut)
+        enrich_future_with_uncaught_warning(fut)
         return fut
 
     def map_unordered(self, func, args):

--- a/cluster_tools/__init__.py
+++ b/cluster_tools/__init__.py
@@ -5,7 +5,7 @@ import sys
 import threading
 from .schedulers.slurm import SlurmExecutor
 from .schedulers.pbs import PBSExecutor
-from .util import random_string, call
+from .util import random_string, call, enrich_futures_with_uncaught_warning
 from . import pickling
 import importlib
 
@@ -25,6 +25,11 @@ class WrappedProcessPoolExecutor(ProcessPoolExecutor):
 
         ProcessPoolExecutor.__init__(self, **new_kwargs)
 
+    def submit(self, *args, **kwargs):
+
+        fut = super().submit(*args, **kwargs)
+        enrich_futures_with_uncaught_warning(fut)
+        return fut
 
     def map_unordered(self, func, args):
 

--- a/cluster_tools/schedulers/cluster_executor.py
+++ b/cluster_tools/schedulers/cluster_executor.py
@@ -1,6 +1,6 @@
 from concurrent import futures
 import os
-from cluster_tools.util import random_string, local_filename, FileWaitThread
+from cluster_tools.util import random_string, local_filename, FileWaitThread, enrich_futures_with_uncaught_warning, get_function_name
 import threading
 import signal
 import sys
@@ -149,9 +149,14 @@ class ClusterExecutor(futures.Executor):
                 "submit() was invoked on a ClusterExecutor instance even though shutdown() was executed for that instance."
             )
 
+    def create_enriched_future(self):
+        fut = futures.Future()
+        enrich_futures_with_uncaught_warning(fut)
+        return fut
+
     def submit(self, fun, *args, **kwargs):
         """Submit a job to the pool."""
-        fut = futures.Future()
+        fut = self.create_enriched_future()
 
         self.ensure_not_shutdown()
 
@@ -162,7 +167,7 @@ class ClusterExecutor(futures.Executor):
         with open(INFILE_FMT % workerid, "wb") as f:
             f.write(funcser)
 
-        job_name = fun.__name__
+        job_name = get_function_name(fun)
         jobid = self._start(workerid, job_name=job_name)
 
         if self.debug:
@@ -192,7 +197,7 @@ class ClusterExecutor(futures.Executor):
 
         # Submit jobs eagerly
         for index, arg in enumerate(allArgs):
-            fut = futures.Future()
+            fut = self.create_enriched_future()
 
             # Start the job.
             funcser = pickling.dumps((fun, [arg], {}, self.meta_data), True)
@@ -204,7 +209,7 @@ class ClusterExecutor(futures.Executor):
             futs.append(fut)
 
         job_count = len(allArgs)
-        job_name = fun.__name__
+        job_name = get_function_name(fun)
         jobid = self._start(workerid, job_count, job_name)
         
 

--- a/cluster_tools/schedulers/cluster_executor.py
+++ b/cluster_tools/schedulers/cluster_executor.py
@@ -1,6 +1,6 @@
 from concurrent import futures
 import os
-from cluster_tools.util import random_string, local_filename, FileWaitThread, enrich_futures_with_uncaught_warning, get_function_name
+from cluster_tools.util import random_string, local_filename, FileWaitThread, enrich_future_with_uncaught_warning, get_function_name
 import threading
 import signal
 import sys
@@ -151,7 +151,7 @@ class ClusterExecutor(futures.Executor):
 
     def create_enriched_future(self):
         fut = futures.Future()
-        enrich_futures_with_uncaught_warning(fut)
+        enrich_future_with_uncaught_warning(fut)
         return fut
 
     def submit(self, fun, *args, **kwargs):

--- a/cluster_tools/util.py
+++ b/cluster_tools/util.py
@@ -6,6 +6,7 @@ import threading
 import time
 import logging
 import re
+import types
 
 def local_filename(filename=""):
     return os.path.join(os.getenv("CFUT_DIR", ".cfut"), filename)
@@ -158,3 +159,38 @@ class FileWaitThread(threading.Thread):
                                 pass
 
             time.sleep(self.interval)
+
+def get_function_name(fun):
+    # When using functools.partial, __name__ does not exist
+    return fun.__name__ if hasattr(fun, "__name__") else "<unknown function>"
+
+def enrich_futures_with_uncaught_warning(f):
+    """
+    Hooks into relevant methods of the given future so that we can detect
+    whether someone handled the exception potentially thrown by the future.
+    """
+    methods = ["cancel", "result", "exception", "add_done_callback"]
+
+    def warn(future):
+        # By calling exception here, we are increasing cluster_tools_handler_count by 1
+        maybe_exception = future.exception()
+        if maybe_exception is not None:
+            if hasattr(f, "cluster_tools_handler_count") and f.cluster_tools_handler_count <= 1:
+                logging.warning("A future crashed with an exception: {}. Future: {}".format(maybe_exception, future))
+
+    if not hasattr(f, "is_wrapped_by_cluster_tools"):
+        f.is_wrapped_by_cluster_tools = True
+        f.cluster_tools_handler_count = 0
+        f.add_done_callback(warn)
+
+        def hook_method(m):
+            old_method = getattr(f, m)
+
+            def new_method(self, *args, **kwargs):
+                self.cluster_tools_handler_count += 1
+                return old_method(*args, **kwargs)
+
+            setattr(f, m, types.MethodType(new_method, f))
+
+        for m in methods:
+            hook_method(m)

--- a/test.py
+++ b/test.py
@@ -5,6 +5,8 @@ import time
 import sys
 import logging
 from enum import Enum
+from functools import partial
+import os
 
 # "Worker" functions.
 def square(n):
@@ -17,6 +19,10 @@ def sleep(duration):
 
 logging.basicConfig()
 
+def raise_if(msg, bool):
+    if bool:
+        raise Exception("raise_if was called with True: {}".format(msg))
+
 
 def get_executors():
     return [
@@ -28,6 +34,66 @@ def get_executors():
         cluster_tools.get_executor("test_pickling"),
         # cluster_tools.get_executor("pbs"),
     ]
+
+def test_uncaught_warning():
+    """
+    This test ensures that there are warnings for "uncaught" futures.
+    """
+
+    # Log to a specific file which we can check for
+    log_file_name = 'warning.log'
+    logger = logging.getLogger('')
+    logger.setLevel(logging.DEBUG)
+    # create file handler which logs even debug messages
+    os.remove(log_file_name)
+    fh = logging.FileHandler(log_file_name)
+    logger.addHandler(fh)
+
+    cases = [False, True]
+
+    def expect_marker(marker, msg, should_exist=True):
+        maybe_negate = lambda b: b if should_exist else not b
+
+        fh.flush()
+        with open(log_file_name) as file:
+            content = file.read()
+            assert maybe_negate(marker in content), msg
+
+    # In the following 4 cases we check whether there is a/no warning when using
+    # map/submit with/without checking the futures.
+    for exc in get_executors():
+        marker = "map-expect-warning"
+        with exc:
+            exc.map(partial(raise_if, marker), cases)
+        expect_marker(marker, "There should be a warning for an uncaught Future in map")
+
+    for exc in get_executors():
+        marker = "map-dont-expect-warning"
+        with exc:
+            try:
+                list(exc.map(partial(raise_if, marker), cases))
+            except Exception:
+                pass
+        expect_marker(marker, "There should be no warning for an uncaught Future in map", False)
+
+    for exc in get_executors():
+        marker = "submit-expect-warning"
+        with exc:
+            futures = [exc.submit(partial(raise_if, marker), b) for b in cases]
+        expect_marker(marker, "There should be no warning for an uncaught Future in submit")
+
+    for exc in get_executors():
+        marker = "submit-dont-expect-warning"
+        with exc:
+            futures = [exc.submit(partial(raise_if, marker), b) for b in cases]
+            try:
+                for f in futures:
+                    f.result()
+            except Exception:
+                pass
+        expect_marker(marker, "There should be a warning for an uncaught Future in submit", False)
+
+    logger.removeHandler(fh)
 
 
 def test_submit():

--- a/test.py
+++ b/test.py
@@ -45,7 +45,8 @@ def test_uncaught_warning():
     logger = logging.getLogger('')
     logger.setLevel(logging.DEBUG)
     # create file handler which logs even debug messages
-    os.remove(log_file_name)
+    if os.path.exists(log_file_name):
+        os.remove(log_file_name)
     fh = logging.FileHandler(log_file_name)
     logger.addHandler(fh)
 


### PR DESCRIPTION
This PR monkey-patches the futures which are returned by the cluster tools (subclassing was not viable, since we would need to reimplement the default base executors then).
That way, we can check whether relevant methods (`result`, `exception` etc.) were called. If they were not called and a future crashes, we warn about this. We could also raise a hard exception, but I'm not too sure about this. Maybe we merge this as a first version and decide later if we want to throw exceptions, too?