### PR TITLE
Use pickle protocol 4 when dumping

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,6 @@ jobs:
           command: |
             cd ./dockered-slurm
             docker exec slurmctld bash -c "cd /cluster_tools && python36 -m pytest -s test.py"
-            docker exec slurmctld bash -c "cd /cluster_tools && python36 test.py"
 
       - run:
           name: Publish python package

--- a/cluster_tools/__init__.py
+++ b/cluster_tools/__init__.py
@@ -56,7 +56,7 @@ class SequentialExecutor(WrappedProcessPoolExecutor):
         WrappedProcessPoolExecutor.__init__(self, **kwargs)
 
 def pickle_identity(obj):
-    return pickling.loads(pickling.dumps(obj, True))
+    return pickling.loads(pickling.dumps(obj))
 
 def pickle_identity_executor(func, *args, **kwargs):
     result = func(*args, **kwargs)

--- a/cluster_tools/pickling.py
+++ b/cluster_tools/pickling.py
@@ -38,7 +38,7 @@ def file_path_to_absolute_module(file_path):
 
 @warn_after("pickle.dumps", WARNING_TIMEOUT)
 def dumps(*args, **kwargs):
-    pickled = pickle_strategy.dumps(*args, **kwargs)
+    pickled = pickle_strategy.dumps(*args, protocol=4, **kwargs)
     if use_cloudpickle:
         return pickled
 

--- a/cluster_tools/pickling.py
+++ b/cluster_tools/pickling.py
@@ -38,7 +38,10 @@ def file_path_to_absolute_module(file_path):
 
 @warn_after("pickle.dumps", WARNING_TIMEOUT)
 def dumps(*args, **kwargs):
-    pickled = pickle_strategy.dumps(*args, protocol=4, **kwargs)
+    # Protocol 4 allows to serialize objects larger than 4 GiB, but is only supported
+    # beginning from Python 3.4
+    protocol = 4 if sys.version_info[0] >= 3 and sys.version_info[1] >= 4 else 3
+    pickled = pickle_strategy.dumps(*args, protocol=protocol, **kwargs)
     if use_cloudpickle:
         return pickled
 

--- a/cluster_tools/pickling.py
+++ b/cluster_tools/pickling.py
@@ -42,23 +42,8 @@ def dumps(*args, **kwargs):
     # beginning from Python 3.4
     protocol = 4 if sys.version_info[0] >= 3 and sys.version_info[1] >= 4 else 3
     pickled = pickle_strategy.dumps(*args, protocol=protocol, **kwargs)
-    if use_cloudpickle:
-        return pickled
+    return pickled
 
-    main_str = b'__main__'
-    if not main_str in pickled:
-        # No need to do any replacements when __main__ is not
-        # mentioned
-        return pickled
-
-    try:
-        main_path = file_path_to_absolute_module(sys.argv[0])
-        # See [1] for the reasons of this horrible hack
-        # [1] https://stackoverflow.com/a/45630450/896760
-        return pickled.replace(main_str, str.encode(main_path))
-    except Exception as exc:
-        logging.warning("Couldn't do any __main__ replacements. Returning raw pickle. Exception: {}".format(exc))
-        return pickled
 
 @warn_after("pickle.loads", WARNING_TIMEOUT)
 def loads(*args, **kwargs):

--- a/cluster_tools/remote.py
+++ b/cluster_tools/remote.py
@@ -28,14 +28,14 @@ def worker(workerid):
         logging.info("Job computation started (jobid={}, workerid={}).".format(executor.get_current_job_id(), workerid))
         result = True, fun(*args, **kwargs)
         logging.info("Job computation completed.")
-        out = pickling.dumps(result, True)
+        out = pickling.dumps(result)
 
     except Exception as e:
         print(traceback.format_exc())
 
         result = False, format_remote_exc()
         logging.info("Job computation failed.")
-        out = pickling.dumps(result, False)
+        out = pickling.dumps(result)
 
 
     destfile = OUTFILE_FMT % workerid

--- a/cluster_tools/schedulers/cluster_executor.py
+++ b/cluster_tools/schedulers/cluster_executor.py
@@ -163,7 +163,7 @@ class ClusterExecutor(futures.Executor):
         # Start the job.
         workerid = random_string()
 
-        funcser = pickling.dumps((fun, args, kwargs, self.meta_data), True)
+        funcser = pickling.dumps((fun, args, kwargs, self.meta_data))
         with open(INFILE_FMT % workerid, "wb") as f:
             f.write(funcser)
 
@@ -200,7 +200,7 @@ class ClusterExecutor(futures.Executor):
             fut = self.create_enriched_future()
 
             # Start the job.
-            funcser = pickling.dumps((fun, [arg], {}, self.meta_data), True)
+            funcser = pickling.dumps((fun, [arg], {}, self.meta_data))
             infile_name = INFILE_FMT % self.get_workerid_with_index(workerid, index)
 
             with open(infile_name, "wb") as f:

--- a/test.py
+++ b/test.py
@@ -249,21 +249,3 @@ def test_cloudpickle_serialization():
             assert fn != enum_consumer
 
     assert True
-
-class TestClass:
-    pass
-
-def deref_fun_helper(obj):
-    clss, inst, one, two = obj
-    assert one == 1
-    assert two == 2
-    assert isinstance(inst, clss)
-
-def test_dereferencing_main():
-    with cluster_tools.get_executor("slurm", debug=True, keep_logs=True, job_resources={"mem": "10M"}) as executor:
-        fut = executor.submit(deref_fun_helper, (TestClass, TestClass(), 1, 2))
-        fut.result()
-
-if __name__ == "__main__":
-    # Validate that slurm_executor.submit also works when being called from a __main__ module
-    test_dereferencing_main()


### PR DESCRIPTION
- Allows to pickle large objects
- Limits support to python >= 3.4
- Removes support for using functions which were defined in `__main__` as executor functions