### PR TITLE
Re-add workaround for pickled __main__ objects

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,7 @@ jobs:
           command: |
             cd ./dockered-slurm
             docker exec slurmctld bash -c "cd /cluster_tools && python36 -m pytest -s test.py"
+            docker exec slurmctld bash -c "cd /cluster_tools && python36 test.py"
 
       - run:
           name: Publish python package

--- a/cluster_tools/file_formatters.py
+++ b/cluster_tools/file_formatters.py
@@ -1,8 +1,0 @@
-from .util import local_filename
-from os import path
-
-def format_infile_name(cfut_dir, job_id):
-	return path.join(cfut_dir, "cfut.in.%s.pickle" % job_id)
-
-def format_outfile_name(cfut_dir, job_id):
-	return path.join(cfut_dir, "cfut.out.%s.pickle" % job_id)

--- a/cluster_tools/pickling.py
+++ b/cluster_tools/pickling.py
@@ -54,6 +54,19 @@ def dump(*args, **kwargs):
 def loads(*args, **kwargs):
     return pickle_strategy.loads(*args, **kwargs)
 
-@warn_after("pickle.load", WARNING_TIMEOUT)
-def load(*args, **kwargs):
-    return pickle_strategy.load(*args, **kwargs)
+# @warn_after("pickle.load", WARNING_TIMEOUT)
+# def load(*args, **kwargs):
+#     return pickle_strategy.load(*args, **kwargs)
+
+
+class RenameUnpickler(pickle_strategy.Unpickler):
+    def find_class(self, module, name):
+        renamed_module = module
+        custom_main_path = os.environ.get("cfut_main_path", None)
+        if module == "__main__" and custom_main_path is not None:
+            renamed_module = custom_main_path
+
+        return super(RenameUnpickler, self).find_class(renamed_module, name)
+
+def load(f):
+    return RenameUnpickler(f).load()

--- a/cluster_tools/pickling.py
+++ b/cluster_tools/pickling.py
@@ -52,22 +52,18 @@ def dump(*args, **kwargs):
 
 @warn_after("pickle.loads", WARNING_TIMEOUT)
 def loads(*args, **kwargs):
+    assert "custom_main_path" not in kwargs, "loads does not implement support for the argument custom_main_path"
     return pickle_strategy.loads(*args, **kwargs)
-
-# @warn_after("pickle.load", WARNING_TIMEOUT)
-# def load(*args, **kwargs):
-#     return pickle_strategy.load(*args, **kwargs)
-
 
 class RenameUnpickler(pickle_strategy.Unpickler):
     def find_class(self, module, name):
-        # renamed_module = module
-        # custom_main_path = os.environ.get("cfut_main_path", None)
+        renamed_module = module
         if module == "__main__" and self.custom_main_path is not None:
             renamed_module = self.custom_main_path
 
         return super(RenameUnpickler, self).find_class(renamed_module, name)
 
+@warn_after("pickle.load", WARNING_TIMEOUT)
 def load(f, custom_main_path=None):
     unpickler = RenameUnpickler(f)
     unpickler.custom_main_path = custom_main_path

--- a/cluster_tools/pickling.py
+++ b/cluster_tools/pickling.py
@@ -61,12 +61,14 @@ def loads(*args, **kwargs):
 
 class RenameUnpickler(pickle_strategy.Unpickler):
     def find_class(self, module, name):
-        renamed_module = module
-        custom_main_path = os.environ.get("cfut_main_path", None)
-        if module == "__main__" and custom_main_path is not None:
-            renamed_module = custom_main_path
+        # renamed_module = module
+        # custom_main_path = os.environ.get("cfut_main_path", None)
+        if module == "__main__" and self.custom_main_path is not None:
+            renamed_module = self.custom_main_path
 
         return super(RenameUnpickler, self).find_class(renamed_module, name)
 
-def load(f):
-    return RenameUnpickler(f).load()
+def load(f, custom_main_path=None):
+    unpickler = RenameUnpickler(f)
+    unpickler.custom_main_path = custom_main_path
+    return unpickler.load()

--- a/cluster_tools/schedulers/cluster_executor.py
+++ b/cluster_tools/schedulers/cluster_executor.py
@@ -8,9 +8,9 @@ from cluster_tools import pickling
 from cluster_tools.pickling import file_path_to_absolute_module
 import time
 from abc import ABC, abstractmethod
-from cluster_tools.file_formatters import format_infile_name, format_outfile_name
 import logging
 from typing import Union
+from ..util import local_filename
 
 class RemoteException(Exception):
     def __init__(self, error, job_id):
@@ -83,8 +83,6 @@ class ClusterExecutor(futures.Executor):
         cfut.remote <workerid>.
         """
 
-        os.environ["cfut_main_path"] = file_path_to_absolute_module(sys.argv[0])
-
         return self.inner_submit(
             f"{sys.executable} -m cluster_tools.remote {workerid} {self.cfut_dir}",
             job_name=self.job_name if self.job_name is not None else job_name,
@@ -117,11 +115,13 @@ class ClusterExecutor(futures.Executor):
     def get_temp_file_path(self, file_name):
         return os.path.join(self.cfut_dir, file_name)
 
-    def format_infile_name(self, job_id):
-        return format_infile_name(self.cfut_dir, job_id)
+    @staticmethod
+    def format_infile_name(cfut_dir, job_id):
+        return os.path.join(cfut_dir, "cfut.in.%s.pickle" % job_id)
 
-    def format_outfile_name(self, job_id):
-        return format_outfile_name(self.cfut_dir, job_id)
+    @staticmethod
+    def format_outfile_name(cfut_dir, job_id):
+        return os.path.join(cfut_dir, "cfut.out.%s.pickle" % job_id)
 
     def _completion(self, jobid, failed_early):
         """Called whenever a job finishes."""
@@ -143,7 +143,7 @@ class ClusterExecutor(futures.Executor):
                 self.format_log_file_path(jobid)
             )
         else:
-            with open(self.format_outfile_name(workerid), "rb") as f:
+            with open(self.format_outfile_name(self.cfut_dir, workerid), "rb") as f:
                 outdata = f.read()
             success, result = pickling.loads(outdata)
 
@@ -154,8 +154,8 @@ class ClusterExecutor(futures.Executor):
 
         # Clean up communication files.
 
-        infile_name = self.format_infile_name(workerid)
-        outfile_name = self.format_outfile_name(workerid)
+        infile_name = self.format_infile_name(self.cfut_dir, workerid)
+        outfile_name = self.format_outfile_name(self.cfut_dir, workerid)
         self.files_to_clean_up.append(infile_name)
         self.files_to_clean_up.append(outfile_name)
 
@@ -182,8 +182,10 @@ class ClusterExecutor(futures.Executor):
         workerid = random_string()
 
         funcser = pickling.dumps((fun, args, kwargs, self.meta_data))
-        with open(self.format_infile_name(workerid), "wb") as f:
+        with open(self.format_infile_name(self.cfut_dir, workerid), "wb") as f:
             f.write(funcser)
+
+        self.store_main_path_to_meta_file(workerid)
 
         job_name = get_function_name(fun)
         jobid = self._start(workerid, job_name=job_name)
@@ -192,7 +194,7 @@ class ClusterExecutor(futures.Executor):
             print("job submitted: %i" % jobid, file=sys.stderr)
 
         # Thread will wait for it to finish.
-        self.wait_thread.waitFor(self.format_outfile_name(workerid), jobid)
+        self.wait_thread.waitFor(self.format_outfile_name(self.cfut_dir, workerid), jobid)
 
         with self.jobs_lock:
             self.jobs[jobid] = (fut, workerid)
@@ -207,7 +209,15 @@ class ClusterExecutor(futures.Executor):
         return str(jobid) + "_" + str(index)
 
     def get_function_pickle_path(self, workerid):
-        return self.format_infile_name(self.get_workerid_with_index(workerid, "function"))
+        return self.format_infile_name(self.cfut_dir, self.get_workerid_with_index(workerid, "function"))
+
+    @staticmethod
+    def get_main_meta_path(cfut_dir, workerid):
+        return os.path.join(cfut_dir, f"cfut.main_path.{workerid}.txt")
+
+    def store_main_path_to_meta_file(self, workerid):
+        with open(self.get_main_meta_path(self.cfut_dir, workerid), "w") as file:
+            file.write(file_path_to_absolute_module(sys.argv[0]))
 
     def map_to_futures(self, fun, allArgs):
         self.ensure_not_shutdown()
@@ -220,6 +230,7 @@ class ClusterExecutor(futures.Executor):
         self.files_to_clean_up.append(pickled_function_path)
         with open(pickled_function_path, "wb") as file:
             pickling.dump(fun, file)
+        self.store_main_path_to_meta_file(workerid)
 
         # Submit jobs eagerly
         for index, arg in enumerate(allArgs):
@@ -227,7 +238,7 @@ class ClusterExecutor(futures.Executor):
 
             # Start the job.
             funcser = pickling.dumps((pickled_function_path, [arg], {}, self.meta_data))
-            infile_name = self.format_infile_name(self.get_workerid_with_index(workerid, index))
+            infile_name = self.format_infile_name(self.cfut_dir, self.get_workerid_with_index(workerid, index))
 
             with open(infile_name, "wb") as f:
                 f.write(funcser)
@@ -251,7 +262,7 @@ class ClusterExecutor(futures.Executor):
                 # Thread will wait for it to finish.
                 workerid_with_index = self.get_workerid_with_index(workerid, index)
                 self.wait_thread.waitFor(
-                    self.format_outfile_name(workerid_with_index), jobid_with_index
+                    self.format_outfile_name(self.cfut_dir, workerid_with_index), jobid_with_index
                 )
 
                 fut.cluster_jobid = jobid

--- a/cluster_tools/schedulers/cluster_executor.py
+++ b/cluster_tools/schedulers/cluster_executor.py
@@ -5,6 +5,7 @@ import threading
 import signal
 import sys
 from cluster_tools import pickling
+from cluster_tools.pickling import file_path_to_absolute_module
 import time
 from abc import ABC, abstractmethod
 from cluster_tools.file_formatters import format_infile_name, format_outfile_name
@@ -81,6 +82,9 @@ class ClusterExecutor(futures.Executor):
         identifying the new job. The job should run ``python -m
         cfut.remote <workerid>.
         """
+
+        os.environ["cfut_main_path"] = file_path_to_absolute_module(sys.argv[0])
+
         return self.inner_submit(
             f"{sys.executable} -m cluster_tools.remote {workerid} {self.cfut_dir}",
             job_name=self.job_name if self.job_name is not None else job_name,

--- a/test.py
+++ b/test.py
@@ -197,7 +197,7 @@ def test_slurm_cfut_dir():
         assert future.result() == 4
 
     assert os.path.exists(cfut_dir)
-    assert len(os.listdir(cfut_dir)) == 1
+    assert len(os.listdir(cfut_dir)) == 2
 
 
 def test_executor_args():

--- a/test.py
+++ b/test.py
@@ -263,3 +263,21 @@ def test_cloudpickle_serialization():
             assert fn != enum_consumer
 
     assert True
+
+class TestClass:
+    pass
+
+def deref_fun_helper(obj):
+    clss, inst, one, two = obj
+    assert one == 1
+    assert two == 2
+    assert isinstance(inst, clss)
+
+def test_dereferencing_main():
+    with cluster_tools.get_executor("slurm", debug=True, job_resources={"mem": "10M"}) as executor:
+        fut = executor.submit(deref_fun_helper, (TestClass, TestClass(), 1, 2))
+        fut.result()
+
+if __name__ == "__main__":
+    # Validate that slurm_executor.submit also works when being called from a __main__ module
+    test_dereferencing_main()


### PR DESCRIPTION
This PR re-adds a workaround for pickling `__main__` objects (crucial, when the cluster tools are used to distribute code which was defined in the main module).

The workaround works by using a custom unpickler and writing the original main path to disk. When the remote worker is spawned, it checks for that main-path in the meta file and passes that to the custom unpickler.