### PR TITLE
Fix main pickling for array jobs

### DIFF
--- a/cluster_tools/remote.py
+++ b/cluster_tools/remote.py
@@ -37,12 +37,13 @@ def worker(workerid, job_array_index, cfut_dir):
         print("trying to read: ", input_file_name)
         print("working dir: ", os.getcwd())
 
+        custom_main_path = get_custom_main_path(workerid)
         with open(input_file_name, "rb") as f:
-            fun, args, kwargs, meta_data = pickling.load(f, get_custom_main_path(workerid))
+            fun, args, kwargs, meta_data = pickling.load(f, custom_main_path)
 
         if type(fun) == str:
             with open(fun, "rb") as function_file:
-                fun = pickling.load(function_file)
+                fun = pickling.load(function_file, custom_main_path)
 
         setup_logging(meta_data)
         

--- a/test.py
+++ b/test.py
@@ -277,6 +277,8 @@ def test_dereferencing_main():
     with cluster_tools.get_executor("slurm", debug=True, job_resources={"mem": "10M"}) as executor:
         fut = executor.submit(deref_fun_helper, (TestClass, TestClass(), 1, 2))
         fut.result()
+        fut = executor.map(deref_fun_helper, [(TestClass, TestClass(), 1, 2)])
+        fut.result()
 
 if __name__ == "__main__":
     # Validate that slurm_executor.submit also works when being called from a __main__ module

--- a/test.py
+++ b/test.py
@@ -278,7 +278,7 @@ def test_dereferencing_main():
         fut = executor.submit(deref_fun_helper, (TestClass, TestClass(), 1, 2))
         fut.result()
         futs = executor.map_to_futures(deref_fun_helper, [(TestClass, TestClass(), 1, 2)])
-        fut[0].result()
+        futs[0].result()
 
 if __name__ == "__main__":
     # Validate that slurm_executor.submit also works when being called from a __main__ module

--- a/test.py
+++ b/test.py
@@ -277,8 +277,8 @@ def test_dereferencing_main():
     with cluster_tools.get_executor("slurm", debug=True, job_resources={"mem": "10M"}) as executor:
         fut = executor.submit(deref_fun_helper, (TestClass, TestClass(), 1, 2))
         fut.result()
-        fut = executor.map(deref_fun_helper, [(TestClass, TestClass(), 1, 2)])
-        fut.result()
+        futs = executor.map_to_futures(deref_fun_helper, [(TestClass, TestClass(), 1, 2)])
+        fut[0].result()
 
 if __name__ == "__main__":
     # Validate that slurm_executor.submit also works when being called from a __main__ module


### PR DESCRIPTION
For array jobs, the distributed function is pickled and unpickled separately from the other data. When unpickling that function, we have to take care of a potential `custom_main_path`, since the function could be defined in the `__main__` module.