### PR TITLE
Implement log-forwarding capabilities

### DIFF
--- a/cluster_tools/__init__.py
+++ b/cluster_tools/__init__.py
@@ -49,6 +49,16 @@ class WrappedProcessPoolExecutor(ProcessPoolExecutor):
         futs = [self.submit(func, arg) for arg in args]
         return futs
 
+    def forward_log(self, fut):
+        """
+        Similar to the cluster executor, this method Takes a future from which the log file is forwarded to the active
+        process. This method blocks as long as the future is not done.
+        """
+
+        # Since the default behavior of process pool executors is to show the log in the main process
+        # we don't need to do anything except for blocking until the future is done.
+        return fut.result()
+
 
 class SequentialExecutor(WrappedProcessPoolExecutor):
     def __init__(self, **kwargs):

--- a/cluster_tools/tailf.py
+++ b/cluster_tools/tailf.py
@@ -1,0 +1,67 @@
+# Adapted from:
+# Author - Kasun Herath <kasunh01 at gmail.com>
+# Source - https://github.com/kasun/python-tail
+
+import os
+import sys
+import time
+
+class Tail(object):
+    ''' Represents a tail command. '''
+    def __init__(self, tailed_file, callback=sys.stdout.write):
+        ''' Initiate a Tail instance.
+            Check for file validity, assigns callback function to standard out.
+            
+            Arguments:
+                tailed_file - File to be followed. '''
+
+        self.tailed_file = tailed_file
+        self.callback = callback
+        self.is_cancelled = False
+
+    def follow(self, seconds=1):
+        ''' Do a tail follow. If a callback function is registered it is called with every new line. 
+        Else printed to standard out.
+    
+        Arguments:
+            seconds - Number of seconds to wait between each iteration; Defaults to 1. '''
+
+        self.check_file_validity(self.tailed_file)
+        with open(self.tailed_file) as file_:
+            # Don't seek, since we want to print the entire file here.
+            while True:
+                line = file_.readline()
+                if not line:
+                    if self.is_cancelled:
+                        # Only break here so that the rest of the file is consumed
+                        # even when the job result is already available.
+                        return
+                    curr_position = file_.tell()
+                    file_.seek(curr_position)
+                    time.sleep(seconds)
+                else:
+                    self.callback(line)
+
+    def cancel(self):
+        self.is_cancelled = True
+
+    def register_callback(self, func):
+        ''' Overrides default callback function to provided function. '''
+        self.callback = func
+
+    def check_file_validity(self, file_):
+        ''' Check whether the a given file exists, readable and is a file '''
+        if not os.access(file_, os.F_OK):
+            raise TailError("File '%s' does not exist" % (file_))
+        if not os.access(file_, os.R_OK):
+            raise TailError("File '%s' not readable" % (file_))
+        if os.path.isdir(file_):
+            raise TailError("File '%s' is a directory" % (file_))
+
+
+class TailError(Exception):
+    def __init__(self, msg):
+        self.message = msg
+    def __str__(self):
+        return self.message
+

--- a/cluster_tools/util.py
+++ b/cluster_tools/util.py
@@ -129,7 +129,7 @@ class FileWaitThread(threading.Thread):
                     if os.path.exists(filename):
                         # Check for output file as a fast indicator for job completion
                         handle_completed_job(job_id, filename, False)
-                    else:
+                    elif self.executor is not None:
                         status = self.executor.check_for_crashed_job(job_id)
 
                         # We have to re-check for the output file since this could be created in the mean time


### PR DESCRIPTION
Fixes #58. Implement as a method on the executor (used like `executor.forward_log(fut)`). Therefore, it works only for one future at a time (as agreed upon internally).