### PR TITLE
Dont assert py extension

### DIFF
--- a/cluster_tools/pickling.py
+++ b/cluster_tools/pickling.py
@@ -24,7 +24,6 @@ def file_path_to_absolute_module(file_path):
     """
     assert os.path.exists(file_path)
     file_loc, ext = os.path.splitext(file_path)
-    assert ext in ('.py', '.pyc')
     directory, module = os.path.split(file_loc)
     module_path = [module]
     while True:

--- a/cluster_tools/util.py
+++ b/cluster_tools/util.py
@@ -162,7 +162,11 @@ class FileWaitThread(threading.Thread):
 
 def get_function_name(fun):
     # When using functools.partial, __name__ does not exist
-    return fun.__name__ if hasattr(fun, "__name__") else "<unknown function>"
+    try:
+        return fun.__name__ if hasattr(fun, "__name__") else fun.func.__name__
+    except Exception:
+        return "<unknown function>"
+
 
 def enrich_future_with_uncaught_warning(f):
     """


### PR DESCRIPTION
This broke python applications which were started as binaries (e.g., by
putting a script into a bin folder which often don't use file
extensions).
Instead, the code for determining the main file trusts sys.argv[0] now.