### PR TITLE
Add optional parameter to configure start method for multiprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ docker exec -it slurmctld bash
 docker exec -it c1 bash
 ```
 
+Tests can be executed with `python3 -m pytest -s test.py` after entering the container.
+
 ## Credits
 
 Thanks to [sampsyo/clusterfutures](https://github.com/sampsyo/clusterfutures) for providing the slurm core abstraction and [giovtorres/slurm-docker-cluster](https://github.com/giovtorres/slurm-docker-cluster) for providing the slurm docker environment which we use for CI based testing.

--- a/cluster_tools/__init__.py
+++ b/cluster_tools/__init__.py
@@ -9,6 +9,7 @@ from .util import random_string, call, enrich_future_with_uncaught_warning
 from . import pickling
 import importlib
 import multiprocessing
+import logging
 
 def get_existent_kwargs_subset(whitelist, kwargs):
     new_kwargs = {}
@@ -24,11 +25,25 @@ class WrappedProcessPoolExecutor(ProcessPoolExecutor):
     def __init__(self, **kwargs):
         new_kwargs = get_existent_kwargs_subset(PROCESS_POOL_KWARGS_WHITELIST, kwargs)
 
-        # For the purpose of these cluster tools, it shouldn't make a significant difference
-        # whether we use spawn or fork. However, TensorFlow is not fork-safe, see:
-        # https://github.com/tensorflow/tensorflow/issues/5448#issuecomment-258934405
-        multiprocessing.set_start_method("spawn", force=True)
+        self.did_overwrite_start_method = False
+        if "start_method" in kwargs is not None:
+            self.did_overwrite_start_method = True
+            self.old_start_method = multiprocessing.get_start_method()
+            start_method = kwargs["start_method"]
+            logging.info(f"Overwriting start_method to {start_method}. Previous value: {self.old_start_method}")
+            multiprocessing.set_start_method(start_method, force=True)
+
         ProcessPoolExecutor.__init__(self, **new_kwargs)
+
+    def shutdown(self, *args, **kwargs):
+
+        super().shutdown(*args, **kwargs)
+
+        if self.did_overwrite_start_method:
+            logging.info(f"Restoring start_method to original value: {self.old_start_method}.")
+            multiprocessing.set_start_method(self.old_start_method, force=True)
+            self.old_start_method = None
+            self.did_overwrite_start_method = False
 
     def submit(self, *args, **kwargs):
 

--- a/cluster_tools/__init__.py
+++ b/cluster_tools/__init__.py
@@ -26,7 +26,7 @@ class WrappedProcessPoolExecutor(ProcessPoolExecutor):
         new_kwargs = get_existent_kwargs_subset(PROCESS_POOL_KWARGS_WHITELIST, kwargs)
 
         self.did_overwrite_start_method = False
-        if "start_method" in kwargs is not None:
+        if kwargs.get("start_method", None) is not None:
             self.did_overwrite_start_method = True
             self.old_start_method = multiprocessing.get_start_method()
             start_method = kwargs["start_method"]

--- a/cluster_tools/util.py
+++ b/cluster_tools/util.py
@@ -162,7 +162,11 @@ class FileWaitThread(threading.Thread):
 
 def get_function_name(fun):
     # When using functools.partial, __name__ does not exist
-    return fun.__name__ if hasattr(fun, "__name__") else "<unknown function>"
+    try:
+        return fun.__name__ if hasattr(fun, "__name__") else fun.func.__name__
+    except Exception:
+        return "<unknown function>"
+
 
 def enrich_future_with_uncaught_warning(f):
     """

--- a/test.py
+++ b/test.py
@@ -11,6 +11,7 @@ import pytest
 import shutil
 import contextlib
 import io
+import multiprocessing as mp
 
 # "Worker" functions.
 def square(n):
@@ -169,6 +170,25 @@ def test_map():
     for exc in get_executors():
         run_map(exc)
 
+
+def expect_fork():
+    assert mp.get_start_method() == "fork"
+    return True
+
+def expect_spawn():
+    assert mp.get_start_method() == "spawn"
+    return True
+
+def test_map_with_spawn():
+
+    with cluster_tools.get_executor("multiprocessing", max_workers=5) as executor:
+        assert executor.submit(expect_fork).result(), "Multiprocessing should use fork by default"
+
+    with cluster_tools.get_executor("multiprocessing", max_workers=5, start_method="spawn") as executor:
+        assert executor.submit(expect_spawn).result(), "Multiprocessing should use spawn if requested"
+    
+    with cluster_tools.get_executor("slurm", max_workers=5, start_method="spawn") as executor:
+        assert executor.submit(expect_fork).result(), "Slurm should ignore provided start_method"
 
 def test_map_lazy():
     def run_map(executor):

--- a/test.py
+++ b/test.py
@@ -184,6 +184,9 @@ def test_map_with_spawn():
     with cluster_tools.get_executor("multiprocessing", max_workers=5) as executor:
         assert executor.submit(expect_fork).result(), "Multiprocessing should use fork by default"
 
+    with cluster_tools.get_executor("multiprocessing", max_workers=5, start_method=None) as executor:
+        assert executor.submit(expect_fork).result(), "Multiprocessing should use fork if start_method is None"
+
     with cluster_tools.get_executor("multiprocessing", max_workers=5, start_method="spawn") as executor:
         assert executor.submit(expect_spawn).result(), "Multiprocessing should use spawn if requested"
     


### PR DESCRIPTION
See https://github.com/scalableminds/cluster_tools/pull/87 for a bit of context. Callers of `get_executor` may now configure the proper spawn method. When we drop python 3.6 support, we can construct a proper context with the appropriate `start_method` instead of setting that value globally.